### PR TITLE
Update docs to make command compatible with Docker Toolbox

### DIFF
--- a/jenkins_sandbox/README.md
+++ b/jenkins_sandbox/README.md
@@ -30,7 +30,7 @@ the browser on our local system. The current directory (intended to be the
 root of the rpc-gating checkout) is mounted within the container.
 ```
 docker run -d \
-  -p 127.0.0.1:8080:8080 \
+  -p 8080:8080 \
   --volume "$PWD":/opt/jenkins-job rpc-gating/jenkins_sandbox
 ```
 


### PR DESCRIPTION
Leave off the IP address for people using Docker Toolbox as it will be running inside a VM instead.